### PR TITLE
ci: adopt s6 runtime verification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
   build_and_push_latest:
     # this creates an image with the name of the repository, i.e. "docker-airnavradar"
     name: Image Build & Push
-    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@bcf0b94a192e7ca9630f788ecc16acd999541404 # main
+    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@4cf063e5906338b3b92f0fe71d8dbae52c180d99 # main
     with:
       push_enabled: true
       push_destinations: ghcr.io

--- a/.github/workflows/test_build.yaml
+++ b/.github/workflows/test_build.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   test_build:
     name: Test Image Build
-    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@bcf0b94a192e7ca9630f788ecc16acd999541404 # main
+    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@4cf063e5906338b3b92f0fe71d8dbae52c180d99 # main
     with:
       push_enabled: false
       ghcr_repo_owner: ${{ github.repository_owner }}


### PR DESCRIPTION
Bumps the sdre.yml pin so builds are verified against the image's s6 service graph before the manifest is published, rather than only being checked for having built. This repo passes none of the inputs removed upstream, so no other workflow change is needed.